### PR TITLE
Bugfix: multiline works now on MacOSX

### DIFF
--- a/examples/multiline.js
+++ b/examples/multiline.js
@@ -13,7 +13,6 @@ var tickId = setInterval(tick, 20);
 
 function tick() {
 	if(count === 99) {
-		bar.terminate();
 		clearInterval(tickId);
 
 		setTimeout(console.log.bind(console, '\nDone!'), 21);

--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -153,18 +153,19 @@ ProgressBar.prototype.render = function (tokens) {
 
   if (this.lastDraw !== str) {
 
-    if(this.lastDraw == null) {
+    if(this.lastDraw === null) {
       this.stream.write('\r');
     }
 
-    var lines = str.split('\n');
-    this.stream.write('\033[' + lines.length + 'A\r');
+    var lines = str.split(/\n/);
+    if(this.lastDraw !== null) {
+        this.stream.write('\033[' + (lines.length-1) + 'A\r');
+    }
     for(var i = 0, len = lines.length - 1; i < len; i++) {
-
       this.stream.cursorTo(0);
-      this.stream.write(lines[i] + '\r');
+      this.stream.write(lines[i]);
       this.stream.clearLine(1);
-
+      this.stream.write('\n');
     }
 
     this.stream.cursorTo(0);


### PR DESCRIPTION
Your code wasn't properly working on my computer. At each tick, it moved one line up until the top of the terminal.

It seems to work better with this correction.